### PR TITLE
chimera-chroot: default to /bin/sh if no shell specifed

### DIFF
--- a/chimera-chroot
+++ b/chimera-chroot
@@ -130,7 +130,7 @@ if [ "$REPLACE_RESOLV" -eq 1 ]; then
     replace_resolv
 fi
 
-chroot "$ROOT_DIR" "$@"
+SHELL=/bin/sh chroot "$ROOT_DIR" "$@"
 RC=$?
 
 restore_resolv


### PR DESCRIPTION
All Chimera Linux default installations come with `/bin/sh` but not necessarily `$SHELL` (e.g. `/bin/bash`); just default to it when no shell is specified as a QoL improvement allowing one to simply:
```
# chimera-chroot /media/root
```
No matter which shell the host may be using.