### PR TITLE
chimera-chroot: default to /bin/sh for Chimera Linux if none specifed

### DIFF
--- a/chimera-chroot
+++ b/chimera-chroot
@@ -130,6 +130,9 @@ if [ "$REPLACE_RESOLV" -eq 1 ]; then
     replace_resolv
 fi
 
+if [ -f "${ROOT_DIR}/etc/chimera-release" ]; then
+    export SHELL=/bin/sh
+fi
 chroot "$ROOT_DIR" "$@"
 RC=$?
 


### PR DESCRIPTION
All Chimera Linux installations come with `/bin/sh` by default but not necessarily `$SHELL`; just default to it when no shell is specified as a QoL improvement allowing one to simply:
```
# chimera-chroot /media/root
```
no matter which shell the host may be using.

(new PR due to force-pushing the branch after closing #3 making it not possible to re-open it afterward)