### PR TITLE
chimera-chroot: add (chroot) prompt prefix

### DIFF
--- a/chimera-chroot
+++ b/chimera-chroot
@@ -133,7 +133,7 @@ fi
 if [ -f "${ROOT_DIR}/etc/chimera-release" ]; then
     export SHELL=/bin/sh
 fi
-chroot "$ROOT_DIR" "$@"
+PS1="(chroot) $PS1" chroot "$ROOT_DIR" "$@"
 RC=$?
 
 restore_resolv


### PR DESCRIPTION
Then it'll be very obvious if you're running commands in or outside of a chroot:
![image](https://github.com/chimera-linux/chimera-install-scripts/assets/47358222/78f3f739-db1a-4533-8681-c5027237a8d5)

as opposed to what currently happens (especially on live install media with default `PS1` as root):
![image](https://github.com/chimera-linux/chimera-install-scripts/assets/47358222/5ea15dc8-5ad6-430c-a7d8-7216d94d67fc)

